### PR TITLE
Add imports to surface area

### DIFF
--- a/symbol_exporter/ast_symbol_extractor.py
+++ b/symbol_exporter/ast_symbol_extractor.py
@@ -31,6 +31,9 @@ class SymbolFinder(ast.NodeVisitor):
 
     def visit_Import(self, node: ast.Import) -> Any:
         self.imported_symbols.extend(k.name for k in node.names)
+        for k in node.names:
+            if not k.asname:
+                self._add_import_to_surface_area(symbol=k.name, shadows=k.name)
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> Any:
@@ -40,6 +43,8 @@ class SymbolFinder(ast.NodeVisitor):
                     module_name = f"{node.module}.{k.name}"
                     self.aliases[k.name] = module_name
                     self.imported_symbols.append(module_name)
+                    if not k.asname:
+                        self._add_import_to_surface_area(symbol=k.name, shadows=module_name)
                 else:
                     self.star_imports.add(node.module)
         self.generic_visit(node)
@@ -48,11 +53,7 @@ class SymbolFinder(ast.NodeVisitor):
         if node.asname:
             alias_name = self.aliases.get(node.name, node.name)
             self.aliases[node.asname] = alias_name
-            self.symbols[f"{self._module_name}.{node.asname}"] = {
-                "type": "import",
-                "lineno": None,
-                "aliases": alias_name,
-            }
+            self._add_import_to_surface_area(symbol=node.asname, shadows=alias_name)
 
     def visit_Attribute(self, node: ast.Attribute) -> Any:
         self.attr_stack.append(node.attr)
@@ -149,6 +150,13 @@ class SymbolFinder(ast.NodeVisitor):
             return fully_qualified_symbol_name
         else:
             return None
+
+    def _add_import_to_surface_area(self, symbol, shadows):
+        self.symbols[f"{self._module_name}.{symbol}"] = {
+            "type": "import",
+            "lineno": None,
+            "shadows": shadows,
+        }
 
 # 1. get all the imports and their aliases (which includes imported things)
 # 2. walk the ast find all usages of those aliases and log all the names and attributes used

--- a/symbol_exporter/ast_symbol_extractor.py
+++ b/symbol_exporter/ast_symbol_extractor.py
@@ -46,7 +46,13 @@ class SymbolFinder(ast.NodeVisitor):
 
     def visit_alias(self, node: ast.alias) -> Any:
         if node.asname:
-            self.aliases[node.asname] = self.aliases.get(node.name, node.name)
+            alias_name = self.aliases.get(node.name, node.name)
+            self.aliases[node.asname] = alias_name
+            self.symbols[f"{self._module_name}.{node.asname}"] = {
+                "type": "import",
+                "lineno": None,
+                "aliases": alias_name,
+            }
 
     def visit_Attribute(self, node: ast.Attribute) -> Any:
         self.attr_stack.append(node.attr)

--- a/tests/test_ast_symbol_extractor.py
+++ b/tests/test_ast_symbol_extractor.py
@@ -1,8 +1,6 @@
 import ast
 from textwrap import dedent
 
-import pytest
-
 from symbol_exporter.ast_symbol_extractor import SymbolFinder
 
 
@@ -21,6 +19,7 @@ def f():
     assert z.used_symbols == {"abc.xyz.i"}
     assert z.symbols == {
         'mm': {'lineno': None, 'symbols_in_volume': set(), 'type': 'module'},
+        "mm.xyz": {"lineno": None, "shadows": "abc.xyz", "type": "import"},
         "mm.f": {"lineno": 4, "symbols_in_volume": {"abc.xyz.i"}, "type": "function"}
     }
 
@@ -40,7 +39,7 @@ def f():
     assert z.used_symbols == {"abc.xyz.i"}
     assert z.symbols == {
         'mm': {'lineno': None, 'symbols_in_volume': set(), 'type': 'module'},
-        "mm.l": {"lineno": None, "type": "import", "aliases": "abc.xyz"},
+        "mm.l": {"lineno": None, "type": "import", "shadows": "abc.xyz"},
         "mm.f": {"lineno": 4, "symbols_in_volume": {"abc.xyz.i"}, "type": "function"}
     }
 
@@ -62,7 +61,8 @@ def f():
     assert z.symbols == {
         "mm": {"lineno": None, "symbols_in_volume": set(), "type": "module"},
         "mm.f": {"lineno": 5, "symbols_in_volume": {"abc.xyz.i"}, "type": "function"},
-        "mm.l": {"lineno": None, "type": "import", "aliases": "abc.xyz"}
+        "mm.xyz": {"lineno": None, "type": "import", "shadows": "abc.xyz"},
+        "mm.l": {"lineno": None, "type": "import", "shadows": "abc.xyz"}
     }
 
 
@@ -86,7 +86,7 @@ def f():
             "symbols_in_volume": {"numpy.ones", "numpy.twos"},
             "type": "function",
         },
-        "mm.np": {"aliases": "numpy", "lineno": None, "type": "import"}
+        "mm.np": {"shadows": "numpy", "lineno": None, "type": "import"}
     }
 
 
@@ -104,7 +104,7 @@ z = np.ones(5)
     assert z.used_symbols == {"numpy.ones"}
     assert z.symbols == {
         'mm': {'lineno': None, 'symbols_in_volume': {"numpy.ones"}, 'type': 'module'},
-        "mm.np": {"aliases": "numpy", "lineno": None, "type": "import"},
+        "mm.np": {"shadows": "numpy", "lineno": None, "type": "import"},
         "mm.z": {"lineno": 4, "symbols_in_volume": set(), "type": "constant"}
     }
 
@@ -124,7 +124,7 @@ class ABC():
     assert z.used_symbols == {"numpy.ones"}
     assert z.symbols == {
         'mm': {'lineno': None, 'symbols_in_volume': set(), 'type': 'module'},
-        "mm.np": {"aliases": "numpy", "lineno": None, "type": "import"},
+        "mm.np": {"shadows": "numpy", "lineno": None, "type": "import"},
         "mm.ABC": {"lineno": 4, "symbols_in_volume": {"numpy.ones"}, "type": "class"}
     }
 
@@ -153,14 +153,11 @@ class ABC():
             "symbols_in_volume": {"numpy.twos"},
             "type": "function",
         },
-        "mm.np": {"aliases": "numpy", "lineno": None, "type": "import"}
+        "mm.np": {"shadows": "numpy", "lineno": None, "type": "import"}
     }
 
 
-@pytest.mark.xfail()
 def test_import_adds_symbols():
-    # np should be a symbol in the surface area since it could be
-    # imported from this code issue #23
     code = """
     import numpy as np
     from abc import xyz as l
@@ -172,15 +169,12 @@ def test_import_adds_symbols():
     tree = ast.parse(dedent(code))
     z = SymbolFinder(module_name="mm")
     z.visit(tree)
-    # assert z.aliases == {'l': 'abc.xyz', 'np': 'numpy'}
-    # TODO: should we add a key in the metadata to say that a symbol is
-    #  a reference to another symbol?
     assert z.symbols == {
-        "mm.np": {'aliases': 'numpy', 'lineno': None, 'type': 'import'},
-        "mm.l": {'aliases': 'abc.xyz', 'lineno': None, 'type': 'import'},
-        "mm.efg": {'aliases': 'ggg.efg', 'lineno': None, 'type': 'import'},
-        "mm.ghi": {'aliases': 'ghi', 'lineno': None, 'type': 'import'},
-        "mm": {'lineno': None, 'symbols_in_volume': {"numpy.ones"}, 'type': 'module'},
+        "mm.np": {"shadows": "numpy", "lineno": None, "type": "import"},
+        "mm.l": {"shadows": "abc.xyz", "lineno": None, "type": "import"},
+        "mm.efg": {"shadows": "ggg.efg", "lineno": None, "type": "import"},
+        "mm.ghi": {"shadows": "ghi", "lineno": None, "type": "import"},
+        "mm": {"lineno": None, "symbols_in_volume": {"numpy.ones"}, "type": "module"},
         "mm.z": {"lineno": 7, "symbols_in_volume": set(), "type": "constant"},
     }
 
@@ -198,7 +192,7 @@ from abc import *
     assert not z.used_symbols
     assert z.star_imports == {"abc"}
     assert z.symbols == {
-        "mm.np": {"aliases": "numpy", "lineno": None, "type": "import"},
+        "mm.np": {"shadows": "numpy", "lineno": None, "type": "import"},
         'mm': {'lineno': None, 'symbols_in_volume': set(), 'type': 'module'}
     }
 
@@ -235,7 +229,7 @@ b = twos(10)
             "lineno": 9,
             "symbols_in_volume": set(),
             "type": "constant"},
-        "mm.np": {"aliases": "numpy", "lineno": None, "type": "import"}
+        "mm.np": {"shadows": "numpy", "lineno": None, "type": "import"}
     }
 
 
@@ -253,6 +247,7 @@ b = twos(10)
     assert z.used_symbols == {"abc.twos"}
     assert z.symbols == {
         'mm': {'lineno': None, 'symbols_in_volume': {"abc.twos"}, 'type': 'module'},
+        "mm.twos": {"lineno": None, "shadows": "abc.twos", "type": "import"},
         "mm.b": {"lineno": 4, "symbols_in_volume": set(), "type": "constant"}
     }
     assert not z.undeclared_symbols
@@ -273,6 +268,7 @@ b = len([])
     assert z.used_builtins == {"len"}
     assert z.symbols == {
         'mm': {'lineno': None, 'symbols_in_volume': {"len"}, 'type': 'module'},
+        "mm.twos": {"lineno": None, "shadows": "abc.twos", "type": "import"},
         "mm.b": {"lineno": 4, "symbols_in_volume": set(), "type": "constant"}
     }
     assert not z.undeclared_symbols
@@ -297,6 +293,7 @@ g = f()
     assert z.symbols == {
         'mm': {'lineno': None, 'symbols_in_volume': {'mm.f'}, 'type': 'module'},
         "mm.f": {"lineno": 4, "symbols_in_volume": set(), "type": "function"},
+        "mm.twos": {"lineno": None, "shadows": "abc.twos", "type": "import"},
         'mm.g': {'lineno': 7, 'symbols_in_volume': set(), 'type': 'constant'}
     }
     assert not z.undeclared_symbols


### PR DESCRIPTION
Currently only adds aliased imports to the surface area.

- [x] Add aliased symbols to surface area: `import numpy as np`
- [x] Add aliased from imports: `from numpy import ones as l`
- [x] Add non-aliased from imports: `from numpy import ones`
- [x] Add non-aliased imports: `import numpy`
- [ ] Add star imports??? not sure if this is needed since we don't know imported symbols