### PR TITLE
Make symbol types ordered

### DIFF
--- a/symbol_exporter/ast_symbol_extractor.py
+++ b/symbol_exporter/ast_symbol_extractor.py
@@ -10,16 +10,41 @@ version = "2"  # must be an integer
 builtin_symbols = set(dir(builtins))
 
 
-class SymbolType(str, Enum):
-    MODULE = "module"
-    IMPORT = "import"
-    FUNCTION = "function"
-    CONSTANT = "constant"
-    CLASS = "class"
-    STAR_IMPORT = "star-import"
-    RELATIVE_IMPORT = "relative-import"
-    RELATIVE_STAR_IMPORT = "relative-star-import"
-    PACKAGE = "package"
+class OrderedEnum(Enum):
+    def __ge__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value >= other.value
+        return NotImplemented
+
+    def __gt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value > other.value
+        return NotImplemented
+
+    def __le__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value <= other.value
+        return NotImplemented
+
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+        return NotImplemented
+
+
+class SymbolType(OrderedEnum):
+    STAR_IMPORT = 1
+    RELATIVE_STAR_IMPORT = 2
+    IMPORT = 3
+    RELATIVE_IMPORT = 4
+    PACKAGE = 5
+    MODULE = 6
+    FUNCTION = 7
+    CONSTANT = 8
+    CLASS = 9
+
+    def __str__(self):
+        return f"{self.name.lower().replace('_', '-')}"
 
 
 class SymbolFinder(ast.NodeVisitor):

--- a/symbol_exporter/db_access_model.py
+++ b/symbol_exporter/db_access_model.py
@@ -3,6 +3,7 @@ import hmac
 import json
 import os
 from datetime import datetime
+from enum import Enum
 
 import dask.bag as db
 from dask.distributed import Client
@@ -136,4 +137,6 @@ class WebDB:
 def make_json_friendly(data):
     if isinstance(data, set):
         return list(sorted(data))
+    if isinstance(data, Enum):
+        return str(data)
     return data

--- a/tests/python_so_extraction/test_so_to_datamodel.py
+++ b/tests/python_so_extraction/test_so_to_datamodel.py
@@ -1,3 +1,4 @@
+from symbol_exporter.ast_symbol_extractor import SymbolType
 from symbol_exporter.python_so_extractor import c_symbols_to_datamodel
 
 
@@ -26,16 +27,16 @@ def test__regex_conversion():
         }
     )
     expected = {
-        "_regex": {"data": {}, "type": "module"},
-        "_regex.CODE_SIZE": {"data": {}, "type": "constant"},
-        "_regex.MAGIC": {"data": {}, "type": "constant"},
-        "_regex.compile": {"data": {}, "type": "function"},
-        "_regex.copyright": {"data": {}, "type": "constant"},
-        "_regex.fold_case": {"data": {}, "type": "function"},
-        "_regex.get_all_cases": {"data": {}, "type": "function"},
-        "_regex.get_code_size": {"data": {}, "type": "function"},
-        "_regex.get_expand_on_folding": {"data": {}, "type": "function"},
-        "_regex.get_properties": {"data": {}, "type": "function"},
-        "_regex.has_property_value": {"data": {}, "type": "function"},
+        "_regex": {"data": {}, "type": SymbolType.MODULE},
+        "_regex.CODE_SIZE": {"data": {}, "type": SymbolType.CONSTANT},
+        "_regex.MAGIC": {"data": {}, "type": SymbolType.CONSTANT},
+        "_regex.compile": {"data": {}, "type": SymbolType.FUNCTION},
+        "_regex.copyright": {"data": {}, "type": SymbolType.CONSTANT},
+        "_regex.fold_case": {"data": {}, "type": SymbolType.FUNCTION},
+        "_regex.get_all_cases": {"data": {}, "type": SymbolType.FUNCTION},
+        "_regex.get_code_size": {"data": {}, "type": SymbolType.FUNCTION},
+        "_regex.get_expand_on_folding": {"data": {}, SymbolType.FUNCTION},
+        "_regex.get_properties": {"data": {}, "type": SymbolType.FUNCTION},
+        "_regex.has_property_value": {"data": {}, "type": SymbolType.FUNCTION},
     }
     assert actual == expected

--- a/tests/python_so_extraction/test_so_to_datamodel.py
+++ b/tests/python_so_extraction/test_so_to_datamodel.py
@@ -35,7 +35,7 @@ def test__regex_conversion():
         "_regex.fold_case": {"data": {}, "type": SymbolType.FUNCTION},
         "_regex.get_all_cases": {"data": {}, "type": SymbolType.FUNCTION},
         "_regex.get_code_size": {"data": {}, "type": SymbolType.FUNCTION},
-        "_regex.get_expand_on_folding": {"data": {}, SymbolType.FUNCTION},
+        "_regex.get_expand_on_folding": {"data": {}, "type": SymbolType.FUNCTION},
         "_regex.get_properties": {"data": {}, "type": SymbolType.FUNCTION},
         "_regex.has_property_value": {"data": {}, "type": SymbolType.FUNCTION},
     }

--- a/tests/test_ast_symbol_extractor.py
+++ b/tests/test_ast_symbol_extractor.py
@@ -1,7 +1,7 @@
 import ast
 from textwrap import dedent
 
-from symbol_exporter.ast_symbol_extractor import SymbolFinder
+from symbol_exporter.ast_symbol_extractor import SymbolFinder, SymbolType
 
 
 def process_code_str(code, module_name="mm"):
@@ -18,11 +18,11 @@ def test_package_name():
     z = process_code_str(code, module_name="__init__")
     assert z.symbols == {
         "__init__": {
-            "type": "package",
+            "type": SymbolType.PACKAGE,
             "data": {},
         },
         "__init__.xyz": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "abc.xyz"},
         },
     }
@@ -35,11 +35,11 @@ def test_fully_qualified_package_names():
     z = process_code_str(code, module_name="mm.__init__")
     assert z.symbols == {
         "mm.__init__": {
-            "type": "package",
+            "type": SymbolType.PACKAGE,
             "data": {},
         },
         "mm.__init__.xyz": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "abc.xyz"},
         },
     }
@@ -52,11 +52,11 @@ def test_fully_qualified_module_names():
     z = process_code_str(code, module_name="mm.core")
     assert z.symbols == {
         "mm.core": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {},
         },
         "mm.core.xyz": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "abc.xyz"},
         },
     }
@@ -75,15 +75,15 @@ def test_from_import_attr_access():
     assert z.used_symbols == {"abc.xyz.i"}
     assert z.symbols == {
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {},
         },
         "mm.xyz": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "abc.xyz"},
         },
         "mm.f": {
-            "type": "function",
+            "type": SymbolType.FUNCTION,
             "data": {
                 "lineno": 4,
                 "symbols_in_volume": {"abc.xyz.i": {"line number": [5]}},
@@ -105,15 +105,15 @@ def test_alias_import():
     assert z.used_symbols == {"abc.xyz.i"}
     assert z.symbols == {
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {},
         },
         "mm.l": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "abc.xyz"},
         },
         "mm.f": {
-            "type": "function",
+            "type": SymbolType.FUNCTION,
             "data": {
                 "lineno": 4,
                 "symbols_in_volume": {"abc.xyz.i": {"line number": [5]}},
@@ -136,22 +136,22 @@ def test_import_with_and_without_alias_exposes_import_and_alias():
     assert z.used_symbols == {"abc.xyz.i"}
     assert z.symbols == {
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {},
         },
         "mm.f": {
-            "type": "function",
+            "type": SymbolType.FUNCTION,
             "data": {
                 "lineno": 5,
                 "symbols_in_volume": {"abc.xyz.i": {"line number": [6]}},
             },
         },
         "mm.xyz": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "abc.xyz"},
         },
         "mm.l": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "abc.xyz"},
         },
     }
@@ -170,11 +170,11 @@ def test_calls():
     assert z.used_symbols == {"numpy.ones", "numpy.twos"}
     assert z.symbols == {
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {},
         },
         "mm.f": {
-            "type": "function",
+            "type": SymbolType.FUNCTION,
             "data": {
                 "lineno": 4,
                 "symbols_in_volume": {
@@ -184,7 +184,7 @@ def test_calls():
             },
         },
         "mm.np": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "numpy"},
         },
     }
@@ -202,15 +202,15 @@ def test_constant():
     assert z.used_symbols == {"numpy.ones"}
     assert z.symbols == {
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {"symbols_in_volume": {"numpy.ones": {"line number": [4]}}},
         },
         "mm.np": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "numpy"},
         },
         "mm.z": {
-            "type": "constant",
+            "type": SymbolType.CONSTANT,
             "data": {"lineno": 4},
         },
     }
@@ -229,15 +229,15 @@ def test_class():
     assert z.used_symbols == {"numpy.ones"}
     assert z.symbols == {
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {},
         },
         "mm.np": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "numpy"},
         },
         "mm.ABC": {
-            "type": "class",
+            "type": SymbolType.CLASS,
             "data": {
                 "lineno": 4,
                 "symbols_in_volume": {"numpy.ones": {"line number": [5]}},
@@ -262,25 +262,25 @@ def test_class_method():
     assert z.used_symbols == {"numpy.ones", "numpy.twos"}
     assert z.symbols == {
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {},
         },
         "mm.ABC": {
-            "type": "class",
+            "type": SymbolType.CLASS,
             "data": {
                 "lineno": 4,
                 "symbols_in_volume": {"numpy.ones": {"line number": [5]}},
             },
         },
         "mm.ABC.xyz": {
-            "type": "function",
+            "type": SymbolType.FUNCTION,
             "data": {
                 "lineno": 7,
                 "symbols_in_volume": {"numpy.twos": {"line number": [8]}},
             },
         },
         "mm.np": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "numpy"},
         },
     }
@@ -298,27 +298,27 @@ def test_import_adds_symbols():
     z = process_code_str(code)
     assert z.symbols == {
         "mm.np": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "numpy"},
         },
         "mm.l": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "abc.xyz"},
         },
         "mm.efg": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "ggg.efg"},
         },
         "mm.ghi": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "ghi"},
         },
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {"symbols_in_volume": {"numpy.ones": {"line number": [7]}}},
         },
         "mm.z": {
-            "type": "constant",
+            "type": SymbolType.CONSTANT,
             "data": {"lineno": 7},
         },
     }
@@ -335,15 +335,15 @@ def test_star_import():
     assert not z.used_symbols
     assert z.symbols == {
         "mm.*": {
-            "type": "star-import",
+            "type": SymbolType.STAR_IMPORT,
             "data": {"imports": {"abc"}},
         },
         "mm.np": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "numpy"},
         },
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {},
         },
     }
@@ -358,19 +358,19 @@ def test_relative_import():
     z = process_code_str(code)
     assert z.symbols == {
         "mm.core": {
-            "type": "relative-import",
+            "type": SymbolType.RELATIVE_IMPORT,
             "data": {"shadows": "core", "level": 1},
         },
         "mm.ones": {
-            "type": "relative-import",
+            "type": SymbolType.RELATIVE_IMPORT,
             "data": {"shadows": "core.ones", "level": 1},
         },
         "mm.twos": {
-            "type": "relative-import",
+            "type": SymbolType.RELATIVE_IMPORT,
             "data": {"shadows": "core.twos", "level": 2},
         },
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {},
         },
     }
@@ -384,17 +384,17 @@ def test_relative_alias_import():
     """
     z = process_code_str(code)
     assert z.symbols == {
-        "mm": {"data": {}, "type": "module"},
+        "mm": {"data": {}, "type": SymbolType.MODULE},
         "mm.c": {
-            "type": "relative-import",
+            "type": SymbolType.RELATIVE_IMPORT,
             "data": {"shadows": "core", "level": 1},
         },
         "mm.c_ones": {
-            "type": "relative-import",
+            "type": SymbolType.RELATIVE_IMPORT,
             "data": {"shadows": "core.ones", "level": 1},
         },
         "mm.c_twos": {
-            "type": "relative-import",
+            "type": SymbolType.RELATIVE_IMPORT,
             "data": {"shadows": "core.twos", "level": 2},
         },
     }
@@ -407,9 +407,9 @@ def test_relative_star_import():
     """
     z = process_code_str(code)
     assert z.symbols == {
-        "mm": {"data": {}, "type": "module"},
+        "mm": {"data": {}, "type": SymbolType.MODULE},
         "mm.relative.*": {
-            "type": "relative-star-import",
+            "type": SymbolType.RELATIVE_STAR_IMPORT,
             "data": {
                 "imports": [
                     {
@@ -446,11 +446,11 @@ def test_undeclared_symbols():
     assert z.undeclared_symbols == {"twos"}
     assert z.symbols == {
         "mm.*": {
-            "type": "star-import",
+            "type": SymbolType.STAR_IMPORT,
             "data": {"imports": {"abc", "xyz"}},
         },
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {
                 "symbols_in_volume": {
                     "numpy.ones": {"line number": [8]},
@@ -459,15 +459,15 @@ def test_undeclared_symbols():
             },
         },
         "mm.a": {
-            "type": "constant",
+            "type": SymbolType.CONSTANT,
             "data": {"lineno": 8},
         },
         "mm.b": {
-            "type": "constant",
+            "type": SymbolType.CONSTANT,
             "data": {"lineno": 9},
         },
         "mm.np": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "numpy"},
         },
     }
@@ -485,15 +485,15 @@ def test_imported_symbols_not_treated_as_undeclared():
     assert z.used_symbols == {"abc.twos"}
     assert z.symbols == {
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {"symbols_in_volume": {"abc.twos": {"line number": [4]}}},
         },
         "mm.twos": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "abc.twos"},
         },
         "mm.b": {
-            "type": "constant",
+            "type": SymbolType.CONSTANT,
             "data": {"lineno": 4},
         },
     }
@@ -513,15 +513,15 @@ def test_builtin_symbols_not_treated_as_undeclared():
     assert z.used_builtins == {"len"}
     assert z.symbols == {
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {"symbols_in_volume": {"len": {"line number": [4]}}},
         },
         "mm.twos": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "abc.twos"},
         },
         "mm.b": {
-            "type": "constant",
+            "type": SymbolType.CONSTANT,
             "data": {"lineno": 4},
         },
     }
@@ -544,19 +544,19 @@ def test_functions_not_treated_as_undeclared():
     assert not z.used_builtins
     assert z.symbols == {
         "mm": {
-            "type": "module",
+            "type": SymbolType.MODULE,
             "data": {"symbols_in_volume": {"mm.f": {"line number": [7]}}},
         },
         "mm.f": {
-            "type": "function",
+            "type": SymbolType.FUNCTION,
             "data": {"lineno": 4},
         },
         "mm.twos": {
-            "type": "import",
+            "type": SymbolType.IMPORT,
             "data": {"shadows": "abc.twos"},
         },
         "mm.g": {
-            "type": "constant",
+            "type": SymbolType.CONSTANT,
             "data": {"lineno": 7},
         },
     }
@@ -579,9 +579,9 @@ def test_attr_assignment():
                     "abc.twos.four": {"line number": [5]},
                 }
             },
-            "type": "module",
+            "type": SymbolType.MODULE,
         },
-        "mm.twos": {"data": {"shadows": "abc.twos"}, "type": "import"},
+        "mm.twos": {"data": {"shadows": "abc.twos"}, "type": SymbolType.IMPORT},
     }
 
 
@@ -595,12 +595,12 @@ def test_out_of_order_func_def():
     """
     z = process_code_str(code)
     assert z.post_process_symbols() == {
-        "mm": {"data": {}, "type": "module"},
+        "mm": {"data": {}, "type": SymbolType.MODULE},
         "mm.a": {
             "data": {"lineno": 2, "symbols_in_volume": {"mm.b": {"line number": [3]}}},
-            "type": "function",
+            "type": SymbolType.FUNCTION,
         },
-        "mm.b": {"data": {"lineno": 5}, "type": "function"},
+        "mm.b": {"data": {"lineno": 5}, "type": SymbolType.FUNCTION},
     }
 
 
@@ -613,13 +613,13 @@ def test_multi_use_of_symbol():
     """
     z = process_code_str(code)
     assert z.post_process_symbols() == {
-        "mm": {"data": {}, "type": "module"},
+        "mm": {"data": {}, "type": SymbolType.MODULE},
         "mm.a": {
             "data": {
                 "lineno": 2,
                 "symbols_in_volume": {"ones": {"line number": [3, 4]}},
             },
-            "type": "function",
+            "type": SymbolType.FUNCTION,
         },
     }
 
@@ -635,10 +635,10 @@ def test_self_is_callable():
     z = process_code_str(code)
     assert z.undeclared_symbols == set()
     assert z.post_process_symbols() == {
-        "mm": {"data": {}, "type": "module"},
-        "mm.A": {"data": {"lineno": 2}, "type": "class"},
-        "mm.A.a": {"data": {"lineno": 3}, "type": "function"},
-        "mm.A.b": {"data": {"lineno": 5}, "type": "function"},
+        "mm": {"data": {}, "type": SymbolType.MODULE},
+        "mm.A": {"data": {"lineno": 2}, "type": SymbolType.CLASS},
+        "mm.A.a": {"data": {"lineno": 3}, "type": SymbolType.FUNCTION},
+        "mm.A.b": {"data": {"lineno": 5}, "type": SymbolType.FUNCTION},
     }
 
 
@@ -659,8 +659,8 @@ def test_symbols_in_volume_names():
                     "mm.z": {"line number": [5]},
                 }
             },
-            "type": "module",
+            "type": SymbolType.MODULE,
         },
-        "mm.ast": {"data": {"shadows": "ast"}, "type": "import"},
-        "mm.z": {"data": {"lineno": 4}, "type": "constant"},
+        "mm.ast": {"data": {"shadows": "ast"}, "type": SymbolType.IMPORT},
+        "mm.z": {"data": {"lineno": 4}, "type": SymbolType.CONSTANT},
     }


### PR DESCRIPTION
We want to have symbol types be actual C-like enumerations.
We do not want to mixin 'int' because enum will then act as int for comparisons and in str representation.
For example, when dumping to JSON the parser will treat it as int and print the int value.

We want the enum to act as an enum but also have explicit ordering.