### PR TITLE
modify symbol table to support redirects for shadows

### DIFF
--- a/symbol_exporter/ast_index.py
+++ b/symbol_exporter/ast_index.py
@@ -65,7 +65,11 @@ def inner_loop(artifact_name):
         symbol_table = symbol_table_with_metadata.get("symbol table", {})
         # update the symbol table
         for k in list(keys):
-            symbol_table.setdefault(k, []).append(artifact_name)
+            symbol_table_entry_value = {'artifact name': artifact_name}
+            shadows = symbols[k].get("data", {}).get("shadows")
+            if shadows:
+                symbol_table_entry_value.update(shadows=shadows)
+            symbol_table.setdefault(k, []).append(symbol_table_entry_value)
         # add artifacts to metadata
         metadata["version"] = version
         metadata.setdefault("indexed artifacts", []).append(artifact_name)

--- a/symbol_exporter/ast_symbol_extractor.py
+++ b/symbol_exporter/ast_symbol_extractor.py
@@ -7,7 +7,7 @@ from enum import Enum
 NOT_A_DEFAULT_ARG = "~~NOT_A_DEFAULT~~"
 RELATIVE_IMPORT_IDENTIFIER = "~~RELATIVE~~"
 # Increment when we need the database to be rebuilt (eg adding a new feature)
-version = "9"  # must be an integer
+version = "10"  # must be an integer
 builtin_symbols = set(dir(builtins))
 
 

--- a/tests/test_api_match.py
+++ b/tests/test_api_match.py
@@ -1,36 +1,50 @@
-from symbol_exporter.api_match import find_supplying_version_set
+from symbol_exporter.api_match import find_supplying_version_set, recursive_get_from_table
 
 SAMPLE_TABLE = {
-    "academic.cli": {
-        "academic-0.2.8-py_0",
-        "academic-0.3.0-py_0",
-        "academic-0.3.1-py_0",
-        "academic-0.4.0-py_0",
-        "academic-0.5.0-py_0",
-        "academic-0.5.1-py_0",
-        "academic-0.6.1-py_0",
-        "academic-0.6.2-py_0",
-        "academic-0.7.0-py_0",
+    "academic": {
+        "academic.cli": [
+            {"artifact name": "academic-0.2.8-py_0"},
+            {"artifact name": "academic-0.3.0-py_0"},
+            {"artifact name": "academic-0.3.1-py_0"},
+            {"artifact name": "academic-0.4.0-py_0"},
+            {"artifact name": "academic-0.5.0-py_0"},
+            {"artifact name": "academic-0.5.1-py_0"},
+            {"artifact name": "academic-0.6.1-py_0"},
+            {"artifact name": "academic-0.6.2-py_0"},
+            {"artifact name": "academic-0.7.0-py_0"},
+        ],
+        "academic.cli.AcademicError": [
+            {"artifact name": "academic-0.5.1-py_0"},
+            {"artifact name": "academic-0.6.1-py_0"},
+            {"artifact name": "academic-0.6.2-py_0"},
+            {"artifact name": "academic-0.7.0-py_0"},
+        ],
+        "academic.cli.clean_bibtex_authors": [
+            {"artifact name": "academic-0.2.8-py_0"},
+            {"artifact name": "academic-0.3.0-py_0"},
+            {"artifact name": "academic-0.3.1-py_0"},
+            {"artifact name": "academic-0.4.0-py_0"},
+            {"artifact name": "academic-0.5.0-py_0"},
+        ],
     },
-    "academic.cli.AcademicError": {
-        "academic-0.5.1-py_0",
-        "academic-0.6.1-py_0",
-        "academic-0.6.2-py_0",
-        "academic-0.7.0-py_0",
+    "zappy": {
+        "zappy": [
+            {"artifact name": "zappy-0.1.0-py_0"},
+            {"artifact name": "zappy-0.2.0-py_0"},
+            {"artifact name": "fork-zappy-0.2.0-py_0"},
+        ]
     },
-    "academic.cli.clean_bibtex_authors": {
-        "academic-0.2.8-py_0",
-        "academic-0.3.0-py_0",
-        "academic-0.3.1-py_0",
-        "academic-0.4.0-py_0",
-        "academic-0.5.0-py_0",
+    "shadow_academic": {
+        "shadow_academic": [
+            {"artifact name": "shadow_academic-0.0.1", "shadows": "academic"},
+            {"artifact name": "shadow_academic-0.0.2", "shadows": "academic"},
+        ]
     },
-    "zappy": {"zappy-0.1.0-py_0", "zappy-0.2.0-py_0"},
 }
 
 
 def get_symbol_table_dummy_func(x):
-    return {'symbol table': SAMPLE_TABLE, 'metadata': {}}
+    return {"symbol table": SAMPLE_TABLE.get(x, {}), "metadata": {}}
 
 
 def test_find_supplying_version_set():
@@ -58,7 +72,7 @@ def test_find_supplying_version_multi_pkg_set():
             "academic-0.6.2-py_0",
             "academic-0.7.0-py_0",
         },
-        "zappy": {"zappy-0.1.0-py_0", "zappy-0.2.0-py_0"},
+        "zappy": {"zappy-0.1.0-py_0", "zappy-0.2.0-py_0", "fork-zappy-0.2.0-py_0"},
     }
 
 
@@ -71,3 +85,74 @@ def test_find_supplying_version_null_set():
 
     intersection, bad = find_supplying_version_set(volume, get_symbol_table_func=get_symbol_table_dummy_func)
     assert intersection == {"academic": set()}
+
+
+def test_find_supplying_version_set_shadows():
+    volume = {"shadow_academic.cli", "shadow_academic.cli.AcademicError"}
+
+    intersection, bad = find_supplying_version_set(volume, get_symbol_table_func=get_symbol_table_dummy_func)
+    assert intersection == {
+        "shadow_academic": {"shadow_academic-0.0.1", "shadow_academic-0.0.2"},
+        "academic": {
+            "academic-0.5.1-py_0",
+            "academic-0.6.1-py_0",
+            "academic-0.6.2-py_0",
+            "academic-0.7.0-py_0",
+        },
+    }
+
+
+def test_recursive_get_from_table():
+    intersection = recursive_get_from_table(
+        "academic.cli.AcademicError", get_symbol_table_func=get_symbol_table_dummy_func
+    )
+    assert intersection == {
+        "academic.cli.AcademicError": [
+            "academic-0.5.1-py_0",
+            "academic-0.6.1-py_0",
+            "academic-0.6.2-py_0",
+            "academic-0.7.0-py_0",
+        ]
+    }
+
+
+def test_recursive_get_from_table_shadows():
+    intersection = recursive_get_from_table(
+        "shadow_academic.cli.AcademicError", get_symbol_table_func=get_symbol_table_dummy_func
+    )
+    assert intersection == {
+        "shadow_academic": ["shadow_academic-0.0.1", "shadow_academic-0.0.2"],
+        "academic.cli.AcademicError": [
+            "academic-0.5.1-py_0",
+            "academic-0.6.1-py_0",
+            "academic-0.6.2-py_0",
+            "academic-0.7.0-py_0",
+        ],
+    }
+
+
+def test_find_supplying_version_null_set_shadows():
+    volume = {
+        "academic.cli",
+        "shadow_academic.cli.AcademicError",
+        "academic.cli.clean_bibtex_authors",
+    }
+
+    intersection, bad = find_supplying_version_set(volume, get_symbol_table_func=get_symbol_table_dummy_func)
+    assert intersection == {"academic": set(), "shadow_academic": {"shadow_academic-0.0.1", "shadow_academic-0.0.2"}}
+
+
+def test_bad_symbol():
+    volume = {"academic.cli.zippy"}
+
+    intersection, bad = find_supplying_version_set(volume, get_symbol_table_func=get_symbol_table_dummy_func)
+    assert intersection == set()
+    assert bad == volume
+
+
+def test_bad_symbol_shadows():
+    volume = {"shadow_academic.cli.zippy"}
+
+    intersection, bad = find_supplying_version_set(volume, get_symbol_table_func=get_symbol_table_dummy_func)
+    assert intersection == set()
+    assert bad == volume


### PR DESCRIPTION
This will allow us to handle shims like `os.path` properly.